### PR TITLE
Compatibility with jekyll 1.0 and refactoring

### DIFF
--- a/_plugins/related_posts.rb
+++ b/_plugins/related_posts.rb
@@ -1,36 +1,34 @@
 require 'jekyll/post'
 
-module RelatedPosts
-
-  # Used to remove #related_posts so that it can be overridden
-  def self.included(klass)
-    klass.class_eval do
-      remove_method :related_posts
-    end
-  end
-
-  # Calculate related posts.
-  #
-  # Returns [<Post>]
-  def related_posts(posts)
-    return [] unless posts.size > 1
-    highest_freq = Jekyll::Post.tag_freq(posts).values.max
-    related_scores = Hash.new(0)
-    posts.each do |post|
-      post.tags.each do |tag|
-        if self.tags.include?(tag) && post != self
-          cat_freq = Jekyll::Post.tag_freq(posts)[tag]
-          related_scores[post] += (1+highest_freq-cat_freq)
-        end
+module Jekyll
+  module RelatedPostsByTags
+    # Used to remove #related_posts so that it can be overridden
+    def self.included(klass)
+      klass.class_eval do
+        remove_method :related_posts
       end
     end
 
-    Jekyll::Post.sort_related_posts(related_scores)
-  end
+    # Calculate related posts.
+    # Returns [<Post>]
+    def related_posts(posts)
+      return [] unless posts.size > 1
+      highest_freq = tag_freq(posts).values.max
+      related_scores = Hash.new(0)
 
-  module ClassMethods
+      posts.each do |post|
+        post.tags.each do |tag|
+          if self.tags.include?(tag) && post != self
+            cat_freq = tag_freq(posts)[tag]
+            related_scores[post] += (1+highest_freq-cat_freq)
+          end
+        end
+      end
+
+      sort_related_posts(related_scores)
+    end
+
     # Calculate the frequency of each tag.
-    #
     # Returns {tag => freq, tag => freq, ...}
     def tag_freq(posts)
       return @tag_freq if @tag_freq
@@ -56,11 +54,7 @@ module RelatedPosts
     end
   end
 
-end
-
-module Jekyll
   class Post
-    include RelatedPosts
-    extend RelatedPosts::ClassMethods
+    include RelatedPostsByTags
   end
 end


### PR DESCRIPTION
plugin not working in jekyll 1.0 branch:

```
nazz.me #dev > jekyll serve
Configuration file: /Library/WebServer/Documents/nazz.me/_config.yml
error: wrong argument type Class (expected Module). Use --trace to view backtrace
nazz.me #dev > jekyll serve --trace
Configuration file: /Library/WebServer/Documents/nazz.me/_config.yml
/Library/WebServer/Documents/nazz.me/_plugins/related_posts.rb:63:in `include': wrong argument type Class (expected Module) (TypeError)
```

Plus slightly simplified plugin structure.
